### PR TITLE
Improve artist speech & header styles on smaller screens

### DIFF
--- a/src/styles/artistSpeech.scss
+++ b/src/styles/artistSpeech.scss
@@ -1,10 +1,19 @@
 .speech {
   .artist-speech {
     display: flex;
+    margin-left: 5rem;
+    max-width: calc(100% - 7rem);
+    @media (max-width: $tabletPortraitPlus) {
+      margin: 0 1rem;
+      max-width: calc(100% - 2rem);
+    }
   }
 
   .artist {
     width: 150px;
+    @media (max-width: $tabletPortraitPlus) {
+      max-width: 30%;
+    }
   }
 
   .speech {
@@ -17,6 +26,11 @@
     position: relative;
     text-align: center;
     width: 320px;
+    @media (max-width: $tabletPortraitPlus) {
+      margin-top: -20px;
+      max-height: 110px;
+      max-width: 62%;
+    }
   }
 
   .speech:before {

--- a/src/styles/artistSpeech.scss
+++ b/src/styles/artistSpeech.scss
@@ -52,24 +52,29 @@
       display: flex;
       height: 100%;
       justify-content: center;
+      margin: 0 1rem;
       position: relative;
       animation: slide-in-from-bottom 0.7s;
     }
     .speech {
       max-height: 120px;
+      width: 60%
     }
     .speech p {
       font-size: 1.2rem;
+      @media (max-width: $tabletPortraitPlus) {
+        font-size: 1rem;
+      }
     }
     .artist {
-      width: 50%;
+      width: 40%;
     }
     button {
       background-color: $plum;
       bottom: 0;
       color: $cream;
       font-weight: 800;
-      margin-bottom: -0.8rem;
+      margin-bottom: -1.2rem;
       margin-left: -1.3rem;
       padding: 0.3rem 0.8rem;
       position: absolute;

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -21,8 +21,8 @@
     }
 
     @media (min-width: $tabletLandscapePlus) {
-      padding: calc(100% / 4 * 0.15);
-      width: calc(100% / 4);
+      padding: calc(100% / 5 * 0.15);
+      width: calc(100% / 5);
     }
 
     .reverse {

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -35,6 +35,13 @@ header {
       outline: 3px solid $pink;
       outline-offset: 3px;
     }
+
+    +a {
+      @media (max-width: $tabletPortraitPlus) {
+        padding-left: 2rem;
+        width: 50%;
+      }
+    }
   }
 
   img {
@@ -148,7 +155,7 @@ footer {
 // Container element to constrain page max-width
 .container {
   width: 100%;
-  max-width: 1000px;
+  max-width: 1200px;
   margin: 0 2rem;
 }
 


### PR DESCRIPTION
Fixes #39 
Fixes #67 

- 5 cards per row on wider screens
- Constrain speech bubble on small screens

NOTE: raised #70  for future potential tidy